### PR TITLE
fix: use stock PocketBase v0.24.2 binary — fixes JS migrations not applying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Stage 1: Build PocketBase Go binary
-FROM golang:1.24-alpine AS go-builder
-
-WORKDIR /build
-COPY backend/pbapp/go.mod backend/pbapp/go.sum ./
-RUN go mod download
-COPY backend/pbapp/ ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /build/pocketbase .
+# Stage 1: Download stock PocketBase binary
+FROM alpine:3.20 AS pb-downloader
+ARG PB_VERSION=0.24.2
+RUN apk add --no-cache curl unzip \
+    && curl -fsSL -o /tmp/pb.zip \
+       "https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip" \
+    && unzip /tmp/pb.zip -d /tmp/pb \
+    && chmod +x /tmp/pb/pocketbase
 
 # Stage 2: Build SvelteKit frontend
 FROM node:18-alpine AS frontend-builder
@@ -37,7 +37,7 @@ FROM node:18-alpine
 RUN apk add --no-cache ca-certificates
 
 # PocketBase
-COPY --from=go-builder /build/pocketbase /pb/pocketbase
+COPY --from=pb-downloader /tmp/pb/pocketbase /pb/pocketbase
 COPY backend/pb_migrations/ /pb/pb_migrations/
 RUN mkdir -p /pb/pb_data /pb/pb_hooks
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -17,14 +17,15 @@ if [ "$RESET_DB" = "true" ]; then
   echo "After wipe: $(ls -la $PB_DIR/pb_data/ 2>&1)"
 fi
 
-# Debug: verify migration files and data dir
-echo "Migration files in $PB_DIR/pb_migrations/:"
-ls -la $PB_DIR/pb_migrations/ 2>&1 | head -10
-echo "Data dir $PB_DIR/pb_data/:"
-ls -la $PB_DIR/pb_data/ 2>&1
+# Apply migrations (stock PocketBase binary handles JS migrations natively)
+echo "Applying migrations..."
+$PB_DIR/pocketbase migrate up --dir=$PB_DIR/pb_data --migrationsDir=$PB_DIR/pb_migrations 2>&1 || echo "migrate up skipped"
 
-# Start PocketBase — the JSVM plugin applies JS migrations automatically on serve
-echo "Starting PocketBase (migrations will apply on startup)..."
+# Create superuser if env vars are set
+if [ -n "$PB_ADMIN_EMAIL" ] && [ -n "$PB_ADMIN_PASSWORD" ]; then
+  echo "Creating superuser..."
+  $PB_DIR/pocketbase superuser upsert "$PB_ADMIN_EMAIL" "$PB_ADMIN_PASSWORD" --dir=$PB_DIR/pb_data 2>&1 || echo "superuser upsert skipped"
+fi
 
 # If frontend build exists, run full-stack mode
 if [ -d "/app/frontend/build" ]; then
@@ -42,12 +43,6 @@ if [ -d "/app/frontend/build" ]; then
     fi
     sleep 1
   done
-
-  # Create superuser after PB is running
-  if [ -n "$PB_ADMIN_EMAIL" ] && [ -n "$PB_ADMIN_PASSWORD" ]; then
-    echo "Creating superuser..."
-    $PB_DIR/pocketbase superuser upsert "$PB_ADMIN_EMAIL" "$PB_ADMIN_PASSWORD" --dir=$PB_DIR/pb_data 2>&1 || echo "superuser upsert skipped"
-  fi
 
   # Start SvelteKit on port 3000 (PORT is scoped to this subprocess only)
   export POCKETBASE_URL=http://127.0.0.1:8090


### PR DESCRIPTION
**This is the fix for collections not appearing on production.**

## Root cause

The Dockerfile built a custom Go binary from `pbapp/main.go` using PocketBase v0.36.1. This binary registers the JSVM plugin for JS migrations, but neither `migrate up` CLI nor `serve` startup actually executes the JS migration files. The stock PocketBase v0.24.2 binary (used in local dev via `pb.sh`) handles JS migrations natively and works correctly.

Evidence:
- Stock binary (`backend/bin/pocketbase`, 42MB, v0.24.2): `migrate up` → `Applied 1700000000_init_collections.js` ✅
- Custom binary (`pbapp/main.go`, 45MB, v0.36.1): `migrate up` → `No new migrations to apply` ❌

## Changes

1. **Dockerfile**: Replace Go build stage with stock PocketBase v0.24.2 download (matches local dev)
2. **entrypoint.sh**: Restore `migrate up` CLI call (works with stock binary), clean up duplicate superuser creation

## Deploy steps

Keep `RESET_DB=true` set. Merge and deploy. Logs should show:
```
Applied 1700000000_init_collections.js
Applied 1700000001_create_tournament_settings.js
... (25 migrations)
```
Then remove `RESET_DB` from Variables.